### PR TITLE
fix: prevent intermittent test abort caused by PanicHookGuard race condition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,13 +214,11 @@ mod tests {
         // metadata_types is empty so run_generate returns NoMetadataTypes
         // before reaching run_tui (which would require /dev/tty).
         let args = make_args(Some("62.0"), Some("out.xml"));
-        let result = crate::run_generate(&client, &args);
-        match result {
-            Err(AppError::ApiVersionError { .. }) => {
-                panic!("get_org_info should not have been called when api_version is specified")
-            }
-            _ => {} // NoMetadataTypes or any non-ApiVersionError is fine
-        }
+        let err = crate::run_generate(&client, &args).unwrap_err();
+        assert!(
+            matches!(err, AppError::NoMetadataTypes),
+            "expected NoMetadataTypes but got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `api_version_specified_skips_get_org_info` テストが macOS（`/dev/tty` アクセス可能）で `run_tui` に到達し、`PanicHookGuard` がテストハーネスのグローバルパニックフックを差し替えることで、間欠的に "thread caused non-unwinding panic. aborting." が発生する問題を修正
- `metadata_types` を空リストにすることで、`run_tui` 到達前に `NoMetadataTypes` で早期リターンさせる
- テストの検証内容（`api_version` 指定時に `get_org_info` がスキップされること）は変更なし

## Test plan

- [x] `cargo test` が 192 件すべて通過
- [x] `cargo clippy` が警告なし
- [x] macOS ターミナルから `cargo test` を複数回実行し、abort が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)