### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/mahito1594/sf-pkgen-rs/compare/v0.4.1...v0.4.2) - 2026-03-07
+
+### Fixed
+
+- prevent intermittent test abort caused by PanicHookGuard race condition ([#16](https://github.com/mahito1594/sf-pkgen-rs/pull/16))
+
+### Other
+
+- update TUI keybindings to reflect right pane fuzzy search ([#23](https://github.com/mahito1594/sf-pkgen-rs/pull/23))
+- fix wrong settings ([#22](https://github.com/mahito1594/sf-pkgen-rs/pull/22))
+- add renovate.json ([#21](https://github.com/mahito1594/sf-pkgen-rs/pull/21))
+- add coverage job with cargo-llvm-cov ([#18](https://github.com/mahito1594/sf-pkgen-rs/pull/18))
+
 ## [0.4.1](https://github.com/mahito1594/sf-pkgen-rs/compare/v0.4.0...v0.4.1) - 2026-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "sf-pkgen"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sf-pkgen"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 repository = "https://github.com/mahito1594/sf-pkgen-rs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sf-pkgen`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/mahito1594/sf-pkgen-rs/compare/v0.4.1...v0.4.2) - 2026-03-07

### Fixed

- prevent intermittent test abort caused by PanicHookGuard race condition ([#16](https://github.com/mahito1594/sf-pkgen-rs/pull/16))

### Other

- update TUI keybindings to reflect right pane fuzzy search ([#23](https://github.com/mahito1594/sf-pkgen-rs/pull/23))
- fix wrong settings ([#22](https://github.com/mahito1594/sf-pkgen-rs/pull/22))
- add renovate.json ([#21](https://github.com/mahito1594/sf-pkgen-rs/pull/21))
- add coverage job with cargo-llvm-cov ([#18](https://github.com/mahito1594/sf-pkgen-rs/pull/18))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).