### PR TITLE
ci: add coverage job with cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,45 @@ jobs:
         run: |
           cargo about generate -o NOTICE.check about.hbs
           diff NOTICE NOTICE.check || (echo "NOTICE file is out of date. Run: cargo about generate -o NOTICE about.hbs" && exit 1)
+
+  coverage:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@f23382d582832e41d5eb4fff2bddb06bc5adf8d3 # v2.68.21
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Report coverage summary
+        run: |
+          echo '## Coverage Report' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cargo llvm-cov report >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: lcov-report
+          path: lcov.info
+          retention-days: 30


### PR DESCRIPTION
## Summary

- CI に `coverage` ジョブを追加し、cargo-llvm-cov でテストカバレッジを計測
- GitHub Actions の Job Summary にカバレッジレポートを表示
- LCOV ファイルをアーティファクトとしてアップロード（保持 30 日）

## 設計ポイント

- 既存パターン（SHA ピン留め、キャッシュ、timeout、draft PR スキップ）に準拠
- キャッシュキーを `cargo-coverage-` プレフィックスで分離（coverage ビルドは通常ビルドと異なるバイナリを生成するため）
- `cargo llvm-cov report` は直前の profraw データを再利用するため、テストの二重実行なし
- 追加権限不要（`contents: read` のみ）

Closes #10

## Test plan

- [x] CI の `coverage` ジョブが成功すること
- [x] Job Summary にカバレッジレポートが表示されること
- [x] Artifacts に `lcov-report` がアップロードされていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)