### PR TITLE
docs: update README and docs to reflect recent feature additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,43 +33,18 @@ cargo about generate -o NOTICE about.hbs
 - 依存クレートの追加は `cargo add` コマンドを使うこと（Cargo.toml の手動編集ではなく）
 - 実装計画を求められた場合は、計画を立てた後に改めてユーザーの承認を得てから実装に着手すること
 - ユーザー向けメッセージ（エラーメッセージ、プロンプト等）は英語で記述すること
+- コミットメッセージは Conventional Commits 形式で記述すること（CI の `commitlint` で検証される）。例: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
 
 ## アーキテクチャ
 
-### クレート構成
+詳細は `docs/architecture.md`（アーキテクチャ）、`docs/specification.md`（仕様）を参照。
 
-バイナリクレート単一構成。`src/main.rs` がクレートルートで、モジュール宣言・`run_generate` 関数・`main` 関数を含む。ライブラリクレートは存在しない。インテグレーションテスト（旧 `tests/generate_test.rs`）は `main.rs` 内の `#[cfg(test)] mod tests` に配置し、モック `SfClient` を注入して `run_generate` をテストする。各サブモジュールは `pub(crate)` で可視性を限定している。
+### 重要な制約（コード編集時に注意）
 
-### I/O チャネル
-
-進捗メッセージ・エラー・プロンプトは stderr、TUI は /dev/tty、XML はファイル出力。`--help` / `--version` は clap のデフォルト動作（stdout）に従う。
-
-### 処理フロー (`main.rs: run_generate`)
-
-1. sf CLI 存在確認 → 2. API version 決定 → 3. メタデータ型一覧取得 → 4. TUI で選択 → 5. 出力先決定 → 6. XML 生成・書き込み
-
-各フェーズ境界で `signal::check_interrupted()` により Ctrl+C を検出する。
-
-### sf CLI 連携 (`sf_client.rs`)
-
-`SfClient` trait（`Sync` バウンド付き）で sf CLI との連携を抽象化。`RealSfClient` が実装を持ち、テストではモック実装に差し替え可能。`Sync` バウンドは `runner.rs` のバックグラウンドスレッドに `&dyn SfClient` を渡すために必要。sf CLI の `--json` 出力は ANSI エスケープが混入しうるため、`ansi.rs` で除去してから JSON パースする。`run_sf_command` は子プロセスの SIGINT 終了と `INTERRUPTED` フラグの両方を検出する。
-
-### TUI (`tui.rs` + `tui/`)
-
-状態・描画・イベントを分離した設計:
-- `tui.rs`: モジュール宣言と `run_tui` の re-export
-- `app.rs`: `AppState`（純粋な状態遷移ロジック、I/O なし）
-- `ui.rs`: `draw()`（`AppState` を受け取り描画するだけ、状態変更なし）
-- `event.rs`: `handle_key_event()` → 副作用なしの `Action` enum を返す。`runner.rs` のイベントループが `Action` を解釈して副作用を実行
-- `fuzzy.rs`: `nucleo-matcher` による fuzzy search ラッパー
-- `runner.rs`: ターミナル setup/teardown、`PanicHookGuard`（RAII）でパニック時のターミナル復元を保証、イベントループ、コンポーネントロード。コンポーネントロードは `std::thread::scope` + `mpsc::channel` でバックグラウンドスレッド化されており、sf CLI 呼び出し中もキー入力を受け付ける（同時実行は最大 1 スレッド、`loading_active` フラグで制御）
-
-ワイルドカード（`*`）と個別コンポーネントの選択は排他的。`wildcard.rs` のハードコードリストでフォルダベース型（wildcard 非対応）を判定する。
-
-### シグナルハンドリング (`signal.rs`)
-
-`ctrlc` クレートで Ctrl+C を捕捉し、`AtomicBool` フラグで管理。`run_generate` のフェーズ境界と `run_sf_command` の子プロセス完了後にフラグを確認し、`AppError::Cancelled`（終了コード 130）に変換する。
-
-### エラーと終了コード (`error.rs`)
-
-`AppError` enum の各バリアントが `exit_code()` で終了コードにマッピングされる。`Cancelled` → 130、それ以外 → 1。clap の引数不正は 2。
+- `SfClient` trait は `Sync` バウンドが必要（`runner.rs` のバックグラウンドスレッドで `&dyn SfClient` を渡すため）
+- ワイルドカード（`*`）と個別コンポーネントの選択は排他的。`src/wildcard.rs` の `FOLDER_BASED_TYPES` でフォルダベース型を判定
+- sf CLI の `--json` 出力は ANSI エスケープが混入しうるため `ansi.rs` で除去してから JSON パース
+- `run_sf_command` は子プロセスの SIGINT 終了と `INTERRUPTED` フラグの両方を検出する
+- TUI の各コンポーネントは状態（`app.rs`）・描画（`ui.rs`）・イベント（`event.rs`）を厳密に分離
+- `PanicHookGuard` (RAII) がパニック時のターミナル復元を保証
+- 各フェーズ境界で `signal::check_interrupted()` により Ctrl+C を検出

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sf-pkgen generate -a 62.0 -f package.xml
 | `l` / `Right` | Focus right pane |
 | `Tab` | Toggle pane focus |
 | `Space` | Select / deselect component (right pane) |
-| `/` | Start fuzzy search (left pane) |
+| `/` | Start fuzzy search in the focused pane |
 | `Enter` | Confirm selection |
 | `Esc` | Cancel |
 | `Ctrl+C` | Cancel |
@@ -82,11 +82,15 @@ sf-pkgen generate -a 62.0 -f package.xml
 
 | Key | Action |
 |-----|--------|
-| Type characters | Filter metadata types |
+| Type characters | Filter items in the focused pane |
 | `Backspace` | Delete last character |
 | `Enter` | Confirm search and return to normal mode |
 | `Esc` | Cancel search |
 | `Ctrl+C` | Cancel TUI |
+
+> **Note:** After exiting search mode, the active filter keyword is shown in the pane title as `[keyword]`.
+> The search query is preserved when re-entering search mode with `/`.
+> Switching the selected metadata type in the left pane resets the right pane's search state.
 
 ### Exit Codes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,8 @@ enum Action {
 
 `wildcard.rs` のハードコードリスト（`FOLDER_BASED_TYPES`）でフォルダベース型を判定し、該当する型には `*` エントリを表示しない。
 
+Salesforce の仕様変更でフォルダベース型が増減した場合は `src/wildcard.rs` の `FOLDER_BASED_TYPES` 定数を更新する。参照元: `source-deploy-retrieve` の `metadataRegistry.json`（`folderType` プロパティを持つ型が対象）。
+
 ## シグナルハンドリング
 
 `signal.rs` が Ctrl+C ハンドリングを管理する。


### PR DESCRIPTION
## Summary

- Update TUI keybindings table in README: generalize `/` description to cover both left and right pane fuzzy search (added in #7)
- Add note about filter keyword display in pane title (added in #11), search query preservation (added in #14), and right pane search reset behavior
- Streamline CLAUDE.md architecture section: replace verbose inline description with a concise "key constraints" list and a reference to `docs/architecture.md`
- Add maintenance note to `docs/architecture.md`: how to update `FOLDER_BASED_TYPES` when Salesforce folder-based types change

## Test plan

- [x] cargo fmt && cargo build && cargo test && cargo clippy pass
- [x] README keybinding descriptions match `src/tui/event.rs` implementation
- [x] Note about filter keyword display matches `src/tui/ui.js` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)