### PR TITLE
feat: support inheriting package selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ sf-pkgen generate [OPTIONS]
 | `--target-org <ALIAS\|USERNAME>` | `-o` | Target org (defaults to sf CLI default org) |
 | `--api-version <VERSION>` | `-a` | API version, e.g. `"62.0"` (defaults to sf CLI default) |
 | `--output-file <PATH>` | `-f` | Output file path (prompted if omitted) |
+| `--inherit <PATH>` |  | Start with selections inherited from an existing `package.xml` |
 
 ### Example
 
@@ -59,6 +60,9 @@ sf-pkgen generate -o my-sandbox -f manifest/package.xml
 
 # Specify API version explicitly
 sf-pkgen generate -a 62.0 -f package.xml
+
+# Start from an existing package.xml and adjust selections in the TUI
+sf-pkgen generate --inherit manifest/package.xml -f package.xml
 ```
 
 ### TUI Keybindings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,10 @@ pub(crate) struct GenerateArgs {
     /// Output file path
     #[arg(short = 'f', long = "output-file")]
     pub(crate) output_file: Option<PathBuf>,
+
+    /// Inherit selections from an existing package.xml
+    #[arg(long = "inherit")]
+    pub(crate) inherit: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub(crate) enum AppError {
     #[error("{message}")]
     OutputPathError { message: String },
 
+    #[error("Failed to parse {path}: {message}")]
+    InheritParseError { path: String, message: String },
+
     #[error("{0}")]
     IoError(#[from] std::io::Error),
 
@@ -69,6 +72,10 @@ mod tests {
                 message: "path error".to_string(),
             },
             AppError::IoError(std::io::Error::new(std::io::ErrorKind::NotFound, "test")),
+            AppError::InheritParseError {
+                path: "/some/path.xml".to_string(),
+                message: "parse failed".to_string(),
+            },
         ];
         for error in &cases {
             assert_eq!(error.exit_code(), 1, "Failed for: {error:?}");

--- a/src/inherit.rs
+++ b/src/inherit.rs
@@ -1,0 +1,897 @@
+// This module implements package.xml inheritance for the --inherit option.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use quick_xml::Reader;
+use quick_xml::escape::unescape;
+use quick_xml::events::Event;
+
+use crate::error::AppError;
+use crate::wildcard;
+
+/// Parsed content of a package.xml used for inheriting selections.
+#[derive(Debug)]
+pub(crate) struct InheritedPackage {
+    /// Map from metadata type name to member list.
+    /// If a type has a wildcard member, the list is exactly `["*"]`.
+    pub(crate) types: HashMap<String, Vec<String>>,
+    /// API version extracted from `<version>`, if present.
+    pub(crate) version: Option<String>,
+}
+
+/// Parses a `package.xml` file and returns the inherited selections.
+///
+/// Returns `AppError::IoError` if the file cannot be read.
+/// Returns `AppError::InheritParseError` if the XML is malformed.
+pub(crate) fn parse_package_xml(path: &Path) -> Result<InheritedPackage, AppError> {
+    let content = std::fs::read_to_string(path)?;
+    parse_xml_content(&content, path)
+}
+
+fn parse_xml_content(content: &str, path: &Path) -> Result<InheritedPackage, AppError> {
+    let mut reader = Reader::from_str(content);
+    reader.config_mut().trim_text(true);
+
+    let path_str = path.to_string_lossy().into_owned();
+
+    let mut types: HashMap<String, Vec<String>> = HashMap::new();
+    let mut version: Option<String> = None;
+
+    let mut in_types = false;
+    let mut current_name: Option<String> = None;
+    let mut current_members: Vec<String> = Vec::new();
+    let mut current_tag: Option<String> = None;
+    // Track open element depth to detect unclosed tags at EOF.
+    let mut depth: i32 = 0;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                depth += 1;
+                let local_name = e.local_name();
+                let tag = std::str::from_utf8(local_name.as_ref()).map_err(|err| {
+                    AppError::InheritParseError {
+                        path: path_str.clone(),
+                        message: format!("invalid UTF-8 in element name: {err}"),
+                    }
+                })?;
+                match tag {
+                    "types" => {
+                        in_types = true;
+                        current_name = None;
+                        current_members = Vec::new();
+                    }
+                    _ => {
+                        current_tag = Some(tag.to_owned());
+                    }
+                }
+            }
+            Ok(Event::Text(e)) => {
+                let decoded = e.decode().map_err(|err| AppError::InheritParseError {
+                    path: path_str.clone(),
+                    message: err.to_string(),
+                })?;
+                let text = unescape(&decoded)
+                    .map_err(|err| AppError::InheritParseError {
+                        path: path_str.clone(),
+                        message: err.to_string(),
+                    })?
+                    .into_owned();
+
+                if in_types {
+                    match current_tag.as_deref() {
+                        Some("name") => current_name = Some(text),
+                        Some("members") => current_members.push(text),
+                        _ => {}
+                    }
+                } else if current_tag.as_deref() == Some("version") {
+                    version = Some(text);
+                }
+            }
+            Ok(Event::End(e)) => {
+                depth -= 1;
+                let local_name = e.local_name();
+                let tag = std::str::from_utf8(local_name.as_ref()).map_err(|err| {
+                    AppError::InheritParseError {
+                        path: path_str.clone(),
+                        message: format!("invalid UTF-8 in element name: {err}"),
+                    }
+                })?;
+                if tag == "types" {
+                    if let Some(name) = current_name.take() {
+                        let members = normalize_members(std::mem::take(&mut current_members));
+                        types
+                            .entry(name)
+                            .and_modify(|existing| {
+                                existing.extend(members.iter().cloned());
+                                *existing = normalize_members(std::mem::take(existing));
+                            })
+                            .or_insert(members);
+                    }
+                    current_members = Vec::new();
+                    in_types = false;
+                }
+                current_tag = None;
+            }
+            Ok(Event::Empty(_)) => {
+                // Self-closing elements do not change depth and carry no text.
+            }
+            Ok(Event::Eof) => {
+                if depth != 0 {
+                    return Err(AppError::InheritParseError {
+                        path: path_str,
+                        message: "unexpected end of file: document is not well-formed".to_string(),
+                    });
+                }
+                break;
+            }
+            Err(e) => {
+                return Err(AppError::InheritParseError {
+                    path: path_str,
+                    message: e.to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(InheritedPackage { types, version })
+}
+
+/// Returns `true` if the member list represents a wildcard selection (`["*"]`).
+pub(crate) fn is_wildcard_members(members: &[String]) -> bool {
+    members.len() == 1 && members[0] == "*"
+}
+
+/// Normalises the member list for a metadata type.
+/// If `*` is present among the members, it wins and all individual members are discarded.
+fn normalize_members(members: Vec<String>) -> Vec<String> {
+    if members.iter().any(|m| m == "*") {
+        vec!["*".to_string()]
+    } else {
+        members
+    }
+}
+
+/// Resolves the inherited package selections against the types and components
+/// available in the current org.
+///
+/// Rules:
+/// - Types not present in `org_types` are skipped with a warning.
+/// - For wildcard types (`["*"]`), the selection is accepted only when the type
+///   supports wildcards; folder-based types (Dashboard, Document, etc.) are skipped
+///   with a warning.
+/// - For individual members, those present in `org_components[type]` are kept;
+///   absent members are skipped with a warning.
+/// - Types in `skipped_member_types` are excluded with a warning because their
+///   components could not be fetched from the org.
+/// - A type whose every individual member is skipped is excluded from the result.
+///
+/// Returns `(selections, warnings)`.
+pub(crate) fn resolve_inherited_selections(
+    inherited: &InheritedPackage,
+    org_types: &HashSet<String>,
+    org_components: &HashMap<String, Vec<String>>,
+    skipped_member_types: &HashSet<String>,
+) -> (HashMap<String, HashSet<String>>, Vec<String>) {
+    let mut selections: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    for (type_name, members) in &inherited.types {
+        if !org_types.contains(type_name) {
+            warnings.push(format!(
+                "Skipping '{type_name}': metadata type not found in the org."
+            ));
+            continue;
+        }
+
+        // Wildcard selection — only valid for types that support it.
+        // Folder-based types (Dashboard, Document, etc.) do not support wildcard.
+        if is_wildcard_members(members) {
+            if !wildcard::supports_wildcard(type_name) {
+                warnings.push(format!(
+                    "Skipping wildcard '*' for '{type_name}': folder-based types do not support wildcard selection."
+                ));
+                continue;
+            }
+            let mut set = HashSet::new();
+            set.insert("*".to_string());
+            selections.insert(type_name.clone(), set);
+            continue;
+        }
+
+        if skipped_member_types.contains(type_name) {
+            warnings.push(format!(
+                "Skipping inherited members for '{type_name}': failed to fetch components from the org."
+            ));
+            continue;
+        }
+
+        // Individual members — validate against known org components.
+        let org_member_list = org_components.get(type_name);
+        let mut selected: HashSet<String> = HashSet::new();
+
+        for member in members {
+            let exists = org_member_list.is_some_and(|list| list.contains(member));
+
+            if exists {
+                selected.insert(member.clone());
+            } else {
+                warnings.push(format!(
+                    "Skipping '{member}' in '{type_name}': component not found in the org."
+                ));
+            }
+        }
+
+        if !selected.is_empty() {
+            selections.insert(type_name.clone(), selected);
+        }
+    }
+
+    (selections, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::io::Write;
+    use std::path::Path;
+
+    use tempfile::NamedTempFile;
+
+    use crate::error::AppError;
+
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    fn write_temp_xml(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(content.as_bytes())
+            .expect("failed to write temp file");
+        file
+    }
+
+    /// Builds a valid package.xml with the given types and version.
+    ///
+    /// Each entry in `types` is `(type_name, members)`.
+    fn make_package_xml(types: &[(&str, &[&str])], version: &str) -> String {
+        let mut xml = String::from(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n",
+        );
+        for (type_name, members) in types {
+            xml.push_str("    <types>\n");
+            for member in *members {
+                xml.push_str(&format!("        <members>{member}</members>\n"));
+            }
+            xml.push_str(&format!("        <name>{type_name}</name>\n"));
+            xml.push_str("    </types>\n");
+        }
+        xml.push_str(&format!("    <version>{version}</version>\n"));
+        xml.push_str("</Package>\n");
+        xml
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_package_xml: normal cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_package_xml_extracts_type_name_and_members() {
+        // Given: a valid package.xml with one type and individual members
+        let xml = make_package_xml(
+            &[("ApexClass", &["AccountController", "ContactService"])],
+            "62.0",
+        );
+        let file = write_temp_xml(&xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: the type and members are extracted correctly
+        let members = result
+            .types
+            .get("ApexClass")
+            .expect("ApexClass should be present");
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&"AccountController".to_string()));
+        assert!(members.contains(&"ContactService".to_string()));
+    }
+
+    #[test]
+    fn parse_package_xml_extracts_version() {
+        // Given: a package.xml with a specific version
+        let xml = make_package_xml(&[("ApexClass", &["*"])], "61.0");
+        let file = write_temp_xml(&xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: the version is extracted
+        assert_eq!(result.version, Some("61.0".to_string()));
+    }
+
+    #[test]
+    fn parse_package_xml_wildcard_member_identified() {
+        // Given: a package.xml with a wildcard member
+        let xml = make_package_xml(&[("ApexClass", &["*"])], "62.0");
+        let file = write_temp_xml(&xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: the type's members list contains only "*"
+        let members = result
+            .types
+            .get("ApexClass")
+            .expect("ApexClass should be present");
+        assert_eq!(members, &vec!["*".to_string()]);
+    }
+
+    #[test]
+    fn parse_package_xml_wildcard_with_individual_members_wildcard_wins() {
+        // Given: a package.xml where a type has both "*" and individual members
+        let xml = make_package_xml(
+            &[("ApexClass", &["AccountController", "*", "ContactService"])],
+            "62.0",
+        );
+        let file = write_temp_xml(&xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: only "*" remains; individual members are discarded
+        let members = result
+            .types
+            .get("ApexClass")
+            .expect("ApexClass should be present");
+        assert_eq!(members, &vec!["*".to_string()]);
+    }
+
+    #[test]
+    fn parse_package_xml_multiple_types() {
+        // Given: a package.xml with multiple metadata types
+        let xml = make_package_xml(
+            &[
+                ("ApexClass", &["*"]),
+                ("CustomObject", &["Account", "Contact"]),
+                ("Report", &["FolderA/MyReport"]),
+            ],
+            "62.0",
+        );
+        let file = write_temp_xml(&xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: all types are present with correct members
+        assert!(result.types.contains_key("ApexClass"));
+        assert!(result.types.contains_key("CustomObject"));
+        assert!(result.types.contains_key("Report"));
+        assert_eq!(result.types.len(), 3);
+    }
+
+    #[test]
+    fn parse_package_xml_merges_repeated_types_blocks() {
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <types>\n\
+                       <members>AccountController</members>\n\
+                       <name>ApexClass</name>\n\
+                   </types>\n\
+                   <types>\n\
+                       <members>ContactService</members>\n\
+                       <name>ApexClass</name>\n\
+                   </types>\n\
+                   <version>62.0</version>\n\
+                   </Package>\n";
+        let file = write_temp_xml(xml);
+
+        let result = parse_package_xml(file.path()).unwrap();
+
+        assert_eq!(
+            result.types.get("ApexClass"),
+            Some(&vec![
+                "AccountController".to_string(),
+                "ContactService".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_package_xml_no_version_returns_none() {
+        // Given: a package.xml with no <version> tag
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   </Package>\n";
+        let file = write_temp_xml(xml);
+
+        // When: parsing the file
+        let result = parse_package_xml(file.path()).unwrap();
+
+        // Then: version is None
+        assert_eq!(result.version, None);
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_package_xml: error cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn parse_package_xml_file_not_found_returns_io_error() {
+        // Given: a path that does not exist
+        let path = Path::new("/nonexistent/path/package.xml");
+
+        // When: parsing a non-existent file
+        let err = parse_package_xml(path).unwrap_err();
+
+        // Then: an IoError is returned
+        assert!(
+            matches!(err, AppError::IoError(_)),
+            "Expected IoError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_package_xml_invalid_xml_returns_inherit_parse_error() {
+        // Given: a file with malformed XML
+        let file = write_temp_xml("this is not xml at all <<<");
+
+        // When: parsing the file
+        let err = parse_package_xml(file.path()).unwrap_err();
+
+        // Then: an InheritParseError is returned (not IoError)
+        assert!(
+            matches!(err, AppError::InheritParseError { .. }),
+            "Expected InheritParseError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_package_xml_unclosed_tag_returns_inherit_parse_error() {
+        // Given: a file with structurally invalid XML (unclosed tag)
+        let file = write_temp_xml(
+            "<?xml version=\"1.0\"?>\n\
+             <Package>\n\
+             <types><name>ApexClass</name>\n",
+        );
+
+        // When: parsing the file
+        let err = parse_package_xml(file.path()).unwrap_err();
+
+        // Then: an InheritParseError is returned
+        assert!(
+            matches!(err, AppError::InheritParseError { .. }),
+            "Expected InheritParseError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_package_xml_error_message_contains_path() {
+        // Given: a file with malformed XML
+        let file = write_temp_xml("not valid xml <<<");
+        let path_str = file.path().to_string_lossy().to_string();
+
+        // When: parsing the file
+        let err = parse_package_xml(file.path()).unwrap_err();
+
+        // Then: the error message references the file path
+        assert!(
+            err.to_string().contains(&path_str),
+            "Error message should contain the file path. Got: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve_inherited_selections: normal cases
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_empty_inherited_returns_empty_result() {
+        // Given: an InheritedPackage with no types
+        let inherited = InheritedPackage {
+            types: HashMap::new(),
+            version: None,
+        };
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: empty selections and no warnings
+        assert!(selections.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_wildcard_type_added_with_wildcard_selection() {
+        // Given: an InheritedPackage with a wildcard type
+        let mut types = HashMap::new();
+        types.insert("ApexClass".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: ApexClass is selected with wildcard, no warnings
+        let selected = selections
+            .get("ApexClass")
+            .expect("ApexClass should be in selections");
+        assert_eq!(selected, &HashSet::from(["*".to_string()]));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_individual_members_present_in_org_are_selected() {
+        // Given: an InheritedPackage with individual members, all present in org
+        let mut types = HashMap::new();
+        types.insert(
+            "ApexClass".to_string(),
+            vec![
+                "AccountController".to_string(),
+                "ContactService".to_string(),
+            ],
+        );
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let mut org_components: HashMap<String, Vec<String>> = HashMap::new();
+        org_components.insert(
+            "ApexClass".to_string(),
+            vec![
+                "AccountController".to_string(),
+                "ContactService".to_string(),
+                "OtherClass".to_string(),
+            ],
+        );
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: both members are selected, no warnings
+        let selected = selections
+            .get("ApexClass")
+            .expect("ApexClass should be in selections");
+        assert!(selected.contains("AccountController"));
+        assert!(selected.contains("ContactService"));
+        assert!(
+            !selected.contains("OtherClass"),
+            "OtherClass was not in inherited"
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_type_not_in_org_is_skipped_with_warning() {
+        // Given: an InheritedPackage with a type that doesn't exist in the org
+        let mut types = HashMap::new();
+        types.insert("ObsoleteType".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: type is not in selections, a warning is emitted
+        assert!(!selections.contains_key("ObsoleteType"));
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("ObsoleteType"),
+            "Warning should mention the skipped type. Got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn resolve_individual_member_not_in_org_is_skipped_with_warning() {
+        // Given: an InheritedPackage where one member doesn't exist in org
+        let mut types = HashMap::new();
+        types.insert(
+            "ApexClass".to_string(),
+            vec!["ExistingClass".to_string(), "DeletedClass".to_string()],
+        );
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let mut org_components: HashMap<String, Vec<String>> = HashMap::new();
+        org_components.insert("ApexClass".to_string(), vec!["ExistingClass".to_string()]);
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: only ExistingClass is selected; DeletedClass emits a warning
+        let selected = selections
+            .get("ApexClass")
+            .expect("ApexClass should be in selections");
+        assert!(selected.contains("ExistingClass"));
+        assert!(!selected.contains("DeletedClass"));
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("DeletedClass"),
+            "Warning should mention the skipped member. Got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn resolve_all_members_missing_from_org_type_excluded_from_selections() {
+        // Given: an InheritedPackage where all members of a type are absent from org
+        let mut types = HashMap::new();
+        types.insert(
+            "ApexClass".to_string(),
+            vec!["GoneClass1".to_string(), "GoneClass2".to_string()],
+        );
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let mut org_components: HashMap<String, Vec<String>> = HashMap::new();
+        org_components.insert("ApexClass".to_string(), vec![]); // no components in org
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: ApexClass is not in selections (no valid members), warnings for each missing member
+        // The type should not appear in selections if no members were resolved
+        assert!(!selections.contains_key("ApexClass") || selections["ApexClass"].is_empty());
+        assert_eq!(warnings.len(), 2);
+    }
+
+    #[test]
+    fn resolve_warnings_are_in_english() {
+        // Given: a type that doesn't exist in the org
+        let mut types = HashMap::new();
+        types.insert("MissingType".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::new();
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (_, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: warning message is in English (contains ASCII-only words typical for English)
+        assert!(!warnings.is_empty());
+        // Basic check: warning contains ASCII text, which is a proxy for English
+        assert!(
+            warnings[0].is_ascii(),
+            "Warning message should be in English (ASCII). Got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn resolve_multiple_types_mix_of_found_and_missing() {
+        // Given: two types — one exists in org, one does not
+        let mut types = HashMap::new();
+        types.insert("ApexClass".to_string(), vec!["*".to_string()]);
+        types.insert("ObsoleteType".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: ApexClass is selected, ObsoleteType is skipped with warning
+        assert!(selections.contains_key("ApexClass"));
+        assert!(!selections.contains_key("ObsoleteType"));
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn resolve_wildcard_selection_contains_only_wildcard() {
+        // Given: a wildcard type in inherited package
+        let mut types = HashMap::new();
+        types.insert("ApexTrigger".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexTrigger".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, _) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: the selection for ApexTrigger is exactly {"*"} — no other members
+        let selected = selections
+            .get("ApexTrigger")
+            .expect("ApexTrigger should be selected");
+        assert_eq!(selected.len(), 1);
+        assert!(selected.contains("*"));
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve_inherited_selections: wildcard exclusion rule
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_does_not_mix_wildcard_and_individual_in_output() {
+        // Given: inherited types already normalized (no * + individual mixing in input)
+        // The output should never have both "*" and individual members for the same type
+        let mut types = HashMap::new();
+        // After parse_package_xml normalization, this would only have ["*"]
+        // But testing defensively with resolved output
+        types.insert("ApexClass".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, _) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: the selection does not contain both "*" and individual members
+        if let Some(selected) = selections.get("ApexClass") {
+            if selected.contains("*") {
+                // If wildcard is present, no individual members should be present
+                assert_eq!(
+                    selected.len(),
+                    1,
+                    "Wildcard selection must contain only '*', got: {selected:?}"
+                );
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // resolve_inherited_selections: folder-based type wildcard guard
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_folder_based_type_with_wildcard_is_skipped_with_warning() {
+        // Given: an inherited package with a folder-based type (Report) using wildcard
+        let mut types = HashMap::new();
+        types.insert("Report".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["Report".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: Report is NOT in selections (folder-based types do not support wildcard)
+        assert!(!selections.contains_key("Report"));
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("Report"),
+            "Warning should mention the skipped type. Got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn resolve_non_folder_based_type_with_wildcard_is_accepted() {
+        // Given: an inherited package with a non-folder-based type (ApexClass) using wildcard
+        let mut types = HashMap::new();
+        types.insert("ApexClass".to_string(), vec!["*".to_string()]);
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+
+        // When: resolving selections
+        let (selections, warnings) =
+            resolve_inherited_selections(&inherited, &org_types, &org_components, &HashSet::new());
+
+        // Then: ApexClass is selected with wildcard and no warnings
+        let selected = selections
+            .get("ApexClass")
+            .expect("ApexClass should be in selections");
+        assert_eq!(selected, &HashSet::from(["*".to_string()]));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_skips_member_types_when_component_fetch_failed() {
+        let mut types = HashMap::new();
+        types.insert(
+            "ApexClass".to_string(),
+            vec!["AccountController".to_string()],
+        );
+        let inherited = InheritedPackage {
+            types,
+            version: None,
+        };
+
+        let org_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+        let org_components: HashMap<String, Vec<String>> = HashMap::new();
+        let skipped_member_types: HashSet<String> = HashSet::from(["ApexClass".to_string()]);
+
+        let (selections, warnings) = resolve_inherited_selections(
+            &inherited,
+            &org_types,
+            &org_components,
+            &skipped_member_types,
+        );
+
+        assert!(!selections.contains_key("ApexClass"));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("ApexClass"));
+        assert!(warnings[0].contains("failed to fetch components"));
+    }
+
+    // -------------------------------------------------------------------------
+    // is_wildcard_members
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn is_wildcard_members_returns_true_for_single_wildcard() {
+        assert!(is_wildcard_members(&["*".to_string()]));
+    }
+
+    #[test]
+    fn is_wildcard_members_returns_false_for_individual_members() {
+        assert!(!is_wildcard_members(&["AccountController".to_string()]));
+    }
+
+    #[test]
+    fn is_wildcard_members_returns_false_for_empty() {
+        assert!(!is_wildcard_members(&[]));
+    }
+
+    #[test]
+    fn is_wildcard_members_returns_false_for_multiple_members_including_wildcard() {
+        // normalize_members would collapse this to ["*"], but is_wildcard_members
+        // checks the slice as-is
+        assert!(!is_wildcard_members(&[
+            "*".to_string(),
+            "AccountController".to_string()
+        ]));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,37 +3,108 @@ mod error;
 mod sf_client;
 
 mod ansi;
+mod inherit;
 mod output;
 mod signal;
 mod tui;
 mod wildcard;
 mod xml;
 
+use std::collections::{HashMap, HashSet};
+
 use clap::Parser;
 use cli::{Cli, GenerateArgs};
 use error::AppError;
 use output::{prompt_output_path, validate_output_path, write_output};
-use sf_client::{RealSfClient, SfClient};
+use sf_client::{MetadataType, RealSfClient, SfClient};
 use xml::{PackageXmlInput, generate_package_xml};
+
+fn resolve_initial_selections(
+    sf_client: &dyn SfClient,
+    args: &GenerateArgs,
+    api_version: &str,
+    metadata_types: &[MetadataType],
+    inherited: Option<&inherit::InheritedPackage>,
+) -> Result<HashMap<String, HashSet<String>>, AppError> {
+    let Some(pkg) = inherited else {
+        return Ok(HashMap::new());
+    };
+
+    let org_type_set: HashSet<String> = metadata_types.iter().map(|t| t.xml_name.clone()).collect();
+
+    // For types with individual members (not wildcard), fetch org components
+    // so that member-level validation and warnings can run before the TUI.
+    let mut org_components: HashMap<String, Vec<String>> = HashMap::new();
+    let mut skipped_member_types: HashSet<String> = HashSet::new();
+    let has_individual_members = pkg
+        .types
+        .values()
+        .any(|members| !inherit::is_wildcard_members(members));
+    if has_individual_members {
+        eprintln!("Fetching components for inherited types...");
+    }
+    for (type_name, members) in &pkg.types {
+        // Wildcard selections and types absent from the org need no component fetch.
+        if inherit::is_wildcard_members(members) || !org_type_set.contains(type_name) {
+            continue;
+        }
+        if let Ok(components) =
+            sf_client.list_metadata(type_name, args.target_org.as_deref(), api_version)
+        {
+            org_components.insert(
+                type_name.clone(),
+                components.into_iter().map(|c| c.full_name).collect(),
+            );
+        } else {
+            skipped_member_types.insert(type_name.clone());
+        }
+        signal::check_interrupted()?;
+    }
+
+    let (selections, warnings) = inherit::resolve_inherited_selections(
+        pkg,
+        &org_type_set,
+        &org_components,
+        &skipped_member_types,
+    );
+    for warning in &warnings {
+        eprintln!("Warning: {warning}");
+    }
+    Ok(selections)
+}
 
 fn run_generate(sf_client: &dyn SfClient, args: &GenerateArgs) -> Result<(), AppError> {
     // 1. Check sf CLI exists
     sf_client.check_sf_exists()?;
     signal::check_interrupted()?;
 
-    // 2. Determine API version
+    // 2. Parse --inherit early so we can fail fast on invalid files and
+    //    use the inherited version when determining the API version.
+    let inherited = match &args.inherit {
+        Some(path) => Some(inherit::parse_package_xml(path)?),
+        None => None,
+    };
+
+    // 3. Determine API version.
+    //    Priority: --api-version > inherited <version> > org info
     let api_version = match &args.api_version {
         Some(v) => v.clone(),
         None => {
-            eprintln!("Fetching API version...");
-            sf_client
-                .get_org_info(args.target_org.as_deref())?
-                .api_version
+            let inherited_version = inherited.as_ref().and_then(|p| p.version.as_ref());
+            match inherited_version {
+                Some(v) => v.clone(),
+                None => {
+                    eprintln!("Fetching API version...");
+                    sf_client
+                        .get_org_info(args.target_org.as_deref())?
+                        .api_version
+                }
+            }
         }
     };
     signal::check_interrupted()?;
 
-    // 3. Fetch metadata types
+    // 4. Fetch metadata types
     eprintln!("Fetching metadata types...");
     let mut metadata_types =
         sf_client.list_metadata_types(args.target_org.as_deref(), &api_version)?;
@@ -46,35 +117,45 @@ fn run_generate(sf_client: &dyn SfClient, args: &GenerateArgs) -> Result<(), App
     // Sort metadata types alphabetically for consistent TUI display
     metadata_types.sort_by(|a, b| a.xml_name.cmp(&b.xml_name));
 
-    // 4. Select metadata types and components
+    // 5. Resolve initial selections from --inherit against org types and components.
+    let initial_selections = resolve_initial_selections(
+        sf_client,
+        args,
+        &api_version,
+        &metadata_types,
+        inherited.as_ref(),
+    )?;
+
+    // 6. Select metadata types and components
     let selections = tui::run_tui(
         metadata_types,
         sf_client,
         args.target_org.as_deref(),
         &api_version,
+        initial_selections,
     )?;
 
-    // 5. Determine output path
+    // 7. Determine output path
     let output_path = match &args.output_file {
         Some(p) => p.clone(),
         None => prompt_output_path()?,
     };
     signal::check_interrupted()?;
 
-    // 6. Validate output path
+    // 8. Validate output path
     validate_output_path(&output_path)?;
 
-    // 7. Generate package.xml
+    // 9. Generate package.xml
     let input = PackageXmlInput {
         types: selections,
         api_version,
     };
     let xml_content = generate_package_xml(&input);
 
-    // 8. Write output
+    // 10. Write output
     write_output(&output_path, &xml_content)?;
 
-    // 9. Done
+    // 11. Done
     eprintln!("Written to {}.", output_path.display());
 
     Ok(())
@@ -117,7 +198,7 @@ mod tests {
         api_version: Option<String>,
         /// If Some, list_metadata_types returns Ok with these types; if None, returns SfCliError
         metadata_types: Option<Vec<MetadataType>>,
-        /// If Some, list_metadata returns components from this map; if None, panics
+        /// If Some, list_metadata returns components from this map; if None, returns SfCliError
         components: Option<HashMap<String, Vec<MetadataComponent>>>,
     }
 
@@ -162,7 +243,9 @@ mod tests {
         ) -> Result<Vec<MetadataComponent>, AppError> {
             match &self.components {
                 Some(map) => Ok(map.get(metadata_type).cloned().unwrap_or_default()),
-                None => panic!("list_metadata should not be called in pre-TUI tests"),
+                None => Err(AppError::SfCliError {
+                    message: "command failed".to_string(),
+                }),
             }
         }
     }
@@ -172,6 +255,7 @@ mod tests {
             target_org: None,
             api_version: api_version.map(String::from),
             output_file: output_file.map(PathBuf::from),
+            inherit: None,
         }
     }
 
@@ -245,5 +329,284 @@ mod tests {
         let args = make_args(Some("62.0"), Some("out.xml"));
         let err = crate::run_generate(&client, &args).unwrap_err();
         assert!(matches!(err, AppError::NoMetadataTypes));
+    }
+
+    // -- API version priority: --api-version > inherited > org fallback --
+
+    /// Creates GenerateArgs with --inherit pointing to a temp file that contains the given XML.
+    fn make_args_with_inherit(
+        xml_content: &str,
+        api_version: Option<&str>,
+    ) -> (GenerateArgs, tempfile::NamedTempFile) {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(xml_content.as_bytes()).expect("write temp");
+        let args = GenerateArgs {
+            target_org: None,
+            api_version: api_version.map(String::from),
+            output_file: Some(PathBuf::from("out.xml")),
+            inherit: Some(file.path().to_path_buf()),
+        };
+        (args, file)
+    }
+
+    fn parse_inherited_from_temp(
+        file: &tempfile::NamedTempFile,
+    ) -> crate::inherit::InheritedPackage {
+        crate::inherit::parse_package_xml(file.path()).expect("parse inherited package")
+    }
+
+    #[test]
+    fn inherit_without_api_version_uses_inherited_version() {
+        // Given: --inherit points to a package.xml with version "60.0"; no --api-version
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <types><members>*</members><name>ApexClass</name></types>\n\
+                   <version>60.0</version>\n\
+                   </Package>\n";
+        let (args, _file) = make_args_with_inherit(xml, None);
+
+        // Client: get_org_info would fail (so if 60.0 is used, get_org_info is NOT called)
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: None, // get_org_info fails → confirms inherited version was used
+            metadata_types: Some(vec![]),
+            components: None,
+        };
+
+        // When: run_generate is called
+        let err = crate::run_generate(&client, &args).unwrap_err();
+
+        // Then: the error is NoMetadataTypes (empty list), NOT ApiVersionError.
+        // If get_org_info had been called, we'd get ApiVersionError instead.
+        assert!(
+            matches!(err, AppError::NoMetadataTypes),
+            "Expected NoMetadataTypes (inherited version used); got: {err}"
+        );
+    }
+
+    #[test]
+    fn explicit_api_version_takes_priority_over_inherited_version() {
+        // Given: --api-version "62.0" is specified AND --inherit has version "60.0"
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <version>60.0</version>\n\
+                   </Package>\n";
+        let (args, _file) = make_args_with_inherit(xml, Some("62.0"));
+
+        // Client: get_org_info would fail (confirms get_org_info is NOT called)
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: None,
+            metadata_types: Some(vec![]),
+            components: None,
+        };
+
+        // When: run_generate is called
+        let err = crate::run_generate(&client, &args).unwrap_err();
+
+        // Then: NoMetadataTypes (62.0 was used, not 60.0; get_org_info was not called)
+        assert!(
+            matches!(err, AppError::NoMetadataTypes),
+            "Expected NoMetadataTypes (explicit api_version used); got: {err}"
+        );
+    }
+
+    #[test]
+    fn inherit_with_no_version_falls_back_to_org_info() {
+        // Given: --inherit points to a package.xml with NO <version>; no --api-version
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   </Package>\n";
+        let (args, _file) = make_args_with_inherit(xml, None);
+
+        // Client: get_org_info returns "62.0"
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: Some("62.0".to_string()), // fallback version from org
+            metadata_types: Some(vec![]),
+            components: None,
+        };
+
+        // When: run_generate is called
+        let err = crate::run_generate(&client, &args).unwrap_err();
+
+        // Then: NoMetadataTypes (62.0 from org info was used as fallback)
+        assert!(
+            matches!(err, AppError::NoMetadataTypes),
+            "Expected NoMetadataTypes (org fallback version used); got: {err}"
+        );
+    }
+
+    #[test]
+    fn inherit_not_specified_behavior_unchanged() {
+        // Given: no --inherit option; existing behavior should be preserved
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: None, // get_org_info fails
+            metadata_types: Some(vec![]),
+            components: None,
+        };
+        // No --inherit, no --api-version: should call get_org_info and get ApiVersionError
+        let args = make_args(None, Some("out.xml"));
+
+        // When: run_generate is called
+        let err = crate::run_generate(&client, &args).unwrap_err();
+
+        // Then: ApiVersionError (exactly as before --inherit was added)
+        assert!(
+            matches!(err, AppError::ApiVersionError { .. }),
+            "Expected ApiVersionError for missing org info without --inherit; got: {err}"
+        );
+    }
+
+    #[test]
+    fn inherit_parse_failure_returns_error_before_api_version_check() {
+        // Given: --inherit points to a non-existent file
+        let args = GenerateArgs {
+            target_org: None,
+            api_version: None,
+            output_file: Some(PathBuf::from("out.xml")),
+            inherit: Some(PathBuf::from("/nonexistent/missing.xml")),
+        };
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: Some("62.0".to_string()),
+            metadata_types: Some(vec![]),
+            components: None,
+        };
+
+        // When: run_generate is called
+        let err = crate::run_generate(&client, &args).unwrap_err();
+
+        // Then: an error is returned (IoError for missing file), not ApiVersionError
+        assert!(
+            matches!(err, AppError::IoError(_)),
+            "Expected IoError for missing --inherit file; got: {err}"
+        );
+    }
+
+    #[test]
+    fn inherit_individual_members_triggers_list_metadata_and_validates() {
+        // Given: --inherit points to a package.xml with ApexClass and individual members.
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <types><members>AccountController</members><name>ApexClass</name></types>\n\
+                   <version>62.0</version>\n\
+                   </Package>\n";
+        let (args, file) = make_args_with_inherit(xml, Some("62.0"));
+
+        let mut components: HashMap<String, Vec<MetadataComponent>> = HashMap::new();
+        components.insert(
+            "ApexClass".to_string(),
+            vec![MetadataComponent {
+                full_name: "AccountController".to_string(),
+            }],
+        );
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: Some("62.0".to_string()),
+            metadata_types: Some(vec![MetadataType {
+                xml_name: "ApexClass".to_string(),
+            }]),
+            components: Some(components),
+        };
+        let metadata_types = vec![MetadataType {
+            xml_name: "ApexClass".to_string(),
+        }];
+        let inherited = parse_inherited_from_temp(&file);
+
+        let selections = crate::resolve_initial_selections(
+            &client,
+            &args,
+            "62.0",
+            &metadata_types,
+            Some(&inherited),
+        )
+        .unwrap();
+
+        assert!(
+            selections
+                .get("ApexClass")
+                .is_some_and(|members| members.contains("AccountController")),
+            "Expected inherited member to be preselected after validation"
+        );
+    }
+
+    #[test]
+    fn inherit_folder_based_type_wildcard_is_skipped_with_warning() {
+        // Given: --inherit points to a package.xml with Report (a folder-based type) using "*".
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <types><members>*</members><name>Report</name></types>\n\
+                   <version>62.0</version>\n\
+                   </Package>\n";
+        let (args, file) = make_args_with_inherit(xml, Some("62.0"));
+
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: Some("62.0".to_string()),
+            metadata_types: Some(vec![MetadataType {
+                xml_name: "Report".to_string(),
+            }]),
+            // Report has wildcard — no list_metadata call expected (skipped in loop).
+            // Using Some(empty map) to avoid panic if called unexpectedly.
+            components: Some(HashMap::new()),
+        };
+        let metadata_types = vec![MetadataType {
+            xml_name: "Report".to_string(),
+        }];
+        let inherited = parse_inherited_from_temp(&file);
+
+        let selections = crate::resolve_initial_selections(
+            &client,
+            &args,
+            "62.0",
+            &metadata_types,
+            Some(&inherited),
+        )
+        .unwrap();
+
+        assert!(
+            !selections.contains_key("Report"),
+            "Expected folder-based wildcard selection to be skipped"
+        );
+    }
+
+    #[test]
+    fn inherit_individual_members_are_skipped_when_component_fetch_fails() {
+        let xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                   <Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n\
+                   <types><members>AccountController</members><name>ApexClass</name></types>\n\
+                   <version>62.0</version>\n\
+                   </Package>\n";
+        let (args, file) = make_args_with_inherit(xml, Some("62.0"));
+
+        let client = MockSfClient {
+            check_sf_ok: true,
+            api_version: Some("62.0".to_string()),
+            metadata_types: Some(vec![MetadataType {
+                xml_name: "ApexClass".to_string(),
+            }]),
+            components: None,
+        };
+        let metadata_types = vec![MetadataType {
+            xml_name: "ApexClass".to_string(),
+        }];
+        let inherited = parse_inherited_from_temp(&file);
+
+        let selections = crate::resolve_initial_selections(
+            &client,
+            &args,
+            "62.0",
+            &metadata_types,
+            Some(&inherited),
+        )
+        .unwrap();
+
+        assert!(
+            !selections.contains_key("ApexClass"),
+            "Expected unresolved inherited members to be skipped"
+        );
     }
 }

--- a/src/tui/runner.rs
+++ b/src/tui/runner.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::panic::{self, PanicHookInfo};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -74,6 +74,7 @@ pub(crate) fn run_tui(
     sf_client: &dyn SfClient,
     target_org: Option<&str>,
     api_version: &str,
+    initial_selections: HashMap<String, HashSet<String>>,
 ) -> Result<BTreeMap<String, Vec<String>>, AppError> {
     let mut tty = open_tty()?;
 
@@ -100,6 +101,7 @@ pub(crate) fn run_tui(
     })?;
 
     let mut app = AppState::new(metadata_types);
+    app.selections = initial_selections;
 
     // Initial component load for the first highlighted type
     if let Some(type_name) = app.request_components_if_needed() {


### PR DESCRIPTION
## Summary
Add `--inherit <PATH>` to seed the TUI from an existing `package.xml`.

Closes #25.

## What Changed
- parse inherited `package.xml` files and reuse the inherited API version when `--api-version` is omitted
- preload TUI selections from inherited metadata members and wildcard entries
- ignore unresolved inherited entries with warnings, including failed component lookups and folder-based wildcard cases
- add parser, resolution, and generate-flow tests for the new inheritance behavior

## Why
Users with an existing `package.xml` should be able to start from that manifest, adjust selections interactively, and regenerate a new file without rebuilding selections from scratch.

## Impact
The `generate` command now supports restoring matching selections from an existing manifest while preserving the wildcard exclusivity rules already enforced by the TUI.

## Validation
- `cargo test`