### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/mahito1594/sf-pkgen-rs/compare/v1.1.0...v1.1.1) - 2026-05-19
+
+### Fixed
+
+- *(deps)* update all minor dependency updates ([#74](https://github.com/mahito1594/sf-pkgen-rs/pull/74))
+
+### Other
+
+- *(deps)* lock file maintenance ([#72](https://github.com/mahito1594/sf-pkgen-rs/pull/72))
+- *(deps)* update release-plz/action action to v0.5.129 ([#73](https://github.com/mahito1594/sf-pkgen-rs/pull/73))
+- *(deps)* update taiki-e/install-action action to v2.77.4 ([#71](https://github.com/mahito1594/sf-pkgen-rs/pull/71))
+- *(deps)* update taiki-e/install-action action to v2.77.3 ([#70](https://github.com/mahito1594/sf-pkgen-rs/pull/70))
+- *(deps)* update taiki-e/install-action action to v2.77.2 ([#68](https://github.com/mahito1594/sf-pkgen-rs/pull/68))
+- *(deps)* update rust crate quick-xml to v0.39.4 ([#69](https://github.com/mahito1594/sf-pkgen-rs/pull/69))
+- *(deps)* update rust crate quick-xml to v0.39.3 ([#67](https://github.com/mahito1594/sf-pkgen-rs/pull/67))
+- *(deps)* lock file maintenance ([#66](https://github.com/mahito1594/sf-pkgen-rs/pull/66))
+- *(deps)* update taiki-e/install-action action to v2.75.30 ([#65](https://github.com/mahito1594/sf-pkgen-rs/pull/65))
+- *(deps)* update taiki-e/install-action action to v2.75.29 ([#64](https://github.com/mahito1594/sf-pkgen-rs/pull/64))
+- *(deps)* update taiki-e/install-action action to v2.75.28 ([#63](https://github.com/mahito1594/sf-pkgen-rs/pull/63))
+- *(deps)* update taiki-e/install-action action to v2.75.27 ([#62](https://github.com/mahito1594/sf-pkgen-rs/pull/62))
+- *(deps)* update taiki-e/install-action action to v2.75.22 ([#61](https://github.com/mahito1594/sf-pkgen-rs/pull/61))
+- *(deps)* lock file maintenance ([#59](https://github.com/mahito1594/sf-pkgen-rs/pull/59))
+- *(deps)* update taiki-e/install-action action to v2.75.21 ([#60](https://github.com/mahito1594/sf-pkgen-rs/pull/60))
+- *(deps)* update taiki-e/install-action action to v2.75.18 ([#58](https://github.com/mahito1594/sf-pkgen-rs/pull/58))
+- *(deps)* update taiki-e/install-action action to v2.75.17 ([#57](https://github.com/mahito1594/sf-pkgen-rs/pull/57))
+- *(deps)* update taiki-e/install-action action to v2.75.16 ([#56](https://github.com/mahito1594/sf-pkgen-rs/pull/56))
+- *(deps)* update rust crate clap to v4.6.1 ([#55](https://github.com/mahito1594/sf-pkgen-rs/pull/55))
+- *(deps)* update actions/cache action to v5.0.5 ([#54](https://github.com/mahito1594/sf-pkgen-rs/pull/54))
+- *(deps)* lock file maintenance ([#52](https://github.com/mahito1594/sf-pkgen-rs/pull/52))
+
 ## [1.1.0](https://github.com/mahito1594/sf-pkgen-rs/compare/v1.0.0...v1.1.0) - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "sf-pkgen"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sf-pkgen"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 repository = "https://github.com/mahito1594/sf-pkgen-rs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `sf-pkgen`: 1.1.0 -> 1.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/mahito1594/sf-pkgen-rs/compare/v1.1.0...v1.1.1) - 2026-05-19

### Fixed

- *(deps)* update all minor dependency updates ([#74](https://github.com/mahito1594/sf-pkgen-rs/pull/74))

### Other

- *(deps)* lock file maintenance ([#72](https://github.com/mahito1594/sf-pkgen-rs/pull/72))
- *(deps)* update release-plz/action action to v0.5.129 ([#73](https://github.com/mahito1594/sf-pkgen-rs/pull/73))
- *(deps)* update taiki-e/install-action action to v2.77.4 ([#71](https://github.com/mahito1594/sf-pkgen-rs/pull/71))
- *(deps)* update taiki-e/install-action action to v2.77.3 ([#70](https://github.com/mahito1594/sf-pkgen-rs/pull/70))
- *(deps)* update taiki-e/install-action action to v2.77.2 ([#68](https://github.com/mahito1594/sf-pkgen-rs/pull/68))
- *(deps)* update rust crate quick-xml to v0.39.4 ([#69](https://github.com/mahito1594/sf-pkgen-rs/pull/69))
- *(deps)* update rust crate quick-xml to v0.39.3 ([#67](https://github.com/mahito1594/sf-pkgen-rs/pull/67))
- *(deps)* lock file maintenance ([#66](https://github.com/mahito1594/sf-pkgen-rs/pull/66))
- *(deps)* update taiki-e/install-action action to v2.75.30 ([#65](https://github.com/mahito1594/sf-pkgen-rs/pull/65))
- *(deps)* update taiki-e/install-action action to v2.75.29 ([#64](https://github.com/mahito1594/sf-pkgen-rs/pull/64))
- *(deps)* update taiki-e/install-action action to v2.75.28 ([#63](https://github.com/mahito1594/sf-pkgen-rs/pull/63))
- *(deps)* update taiki-e/install-action action to v2.75.27 ([#62](https://github.com/mahito1594/sf-pkgen-rs/pull/62))
- *(deps)* update taiki-e/install-action action to v2.75.22 ([#61](https://github.com/mahito1594/sf-pkgen-rs/pull/61))
- *(deps)* lock file maintenance ([#59](https://github.com/mahito1594/sf-pkgen-rs/pull/59))
- *(deps)* update taiki-e/install-action action to v2.75.21 ([#60](https://github.com/mahito1594/sf-pkgen-rs/pull/60))
- *(deps)* update taiki-e/install-action action to v2.75.18 ([#58](https://github.com/mahito1594/sf-pkgen-rs/pull/58))
- *(deps)* update taiki-e/install-action action to v2.75.17 ([#57](https://github.com/mahito1594/sf-pkgen-rs/pull/57))
- *(deps)* update taiki-e/install-action action to v2.75.16 ([#56](https://github.com/mahito1594/sf-pkgen-rs/pull/56))
- *(deps)* update rust crate clap to v4.6.1 ([#55](https://github.com/mahito1594/sf-pkgen-rs/pull/55))
- *(deps)* update actions/cache action to v5.0.5 ([#54](https://github.com/mahito1594/sf-pkgen-rs/pull/54))
- *(deps)* lock file maintenance ([#52](https://github.com/mahito1594/sf-pkgen-rs/pull/52))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).